### PR TITLE
Add calendar

### DIFF
--- a/home/urls.py
+++ b/home/urls.py
@@ -4,6 +4,7 @@ from . import views
 app_name = 'home'
 urlpatterns = [
     path('', views.index, name='index'),
+    path('calendar/', views.calendar, name='calendar'),
     path('new/', views.new_index, name='new_index'),
     path('dashboard/', views.dashboard, name='dashboard'),
     path('dashboard/update_cwhw/', views.update_cwhw, name='update_cwhw'),

--- a/home/views.py
+++ b/home/views.py
@@ -43,6 +43,11 @@ def new_index(request):
     initiatives = Initiative.objects.all()
     return render(request, 'new_home/index.html', {'initiatives': initiatives})
 
+def calendar(request):
+    if request.user.is_authenticated:
+        return render(request, 'calendar.html')
+    return render(request, 'calendar.html')
+
 
 @login_required
 @user_passes_test(

--- a/static/calendar.css
+++ b/static/calendar.css
@@ -1,0 +1,185 @@
+.calendar {
+  --padding: 0 20px;
+  --border-radius: 25px;
+  --side-padding: 20px;
+  --accent-br: 30px;
+}
+
+.calendar-area {
+  display: flex;
+  flex-flow: row wrap;
+}
+.calendar {
+  width: 30%;
+  height: 100%;
+  margin: 10% 2.5%;
+}
+
+/* assigns green background to days with scheduled events */
+.calendar .greenClass {
+  background-color: #dee7de;
+  border-radius: var(--accent-br);
+}
+
+/* assigns red background to days without scheduled events */
+.calendar .redClass {
+  background-color: #fae8dd;
+  border-radius: var(--accent-br);
+}
+
+/* month and year menus */
+.calendar select {
+  background-color: #f5f6f8;
+  padding: 15px 20px;
+}
+
+.options,
+.buttons {
+  background-color: #fff;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  column-gap: 15px;
+}
+
+/* month and year options */
+.options {
+  border-top-left-radius: var(--border-radius);
+  border-top-right-radius: var(--border-radius);
+  padding: 20px var(--side-padding);
+}
+
+.calendar-body {
+  background-image: linear-gradient(to bottom, #f3f4f6, #fff);
+}
+
+/* day names */
+.days {
+  background-color: #fff;
+  padding: 0 var(--side-padding) 10px;
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+}
+
+.days > div {
+  text-align: center;
+  font-weight: 700;
+  font-size: 1.02rem;
+  color: #3f3d56;
+}
+
+/* dates in main calendar body */
+.dates {
+  padding: 10px var(--side-padding);
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+}
+
+.date {
+  --height: calc(400px / 6 - var(--side-padding));
+  text-align: center;
+  height: var(--height);
+  line-height: var(--height);
+  font-weight: 600;
+  font-size: 1.02rem;
+  cursor: pointer;
+  position: relative;
+}
+
+.date span {
+  position: relative;
+  z-index: 1;
+}
+
+.date::before {
+  content: '';
+  position: absolute;
+  width: 100%;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  border-radius: var(--accent-br);
+  transition: background-color 0.3s ease;
+}
+
+/* assigns green background to days if
+1. it is not the current date
+2. if it not a blocked date
+3. if it does not have any scheduled events */
+.date:not(.current-date):not(.date-blocked):not(.redClass) {
+  background-color: #daffda;
+  border-radius: var(--accent-br);
+}
+
+/* makes days from other visible months inaccessible */
+.date-blocked {
+  color: #a8a8a8;
+  cursor: not-allowed;
+}
+
+/* highlights the current day */
+.current-date {
+  color: rgb(63, 61, 86);
+  box-shadow: 0 15px 20px -3px rgba(255, 55, 75, 0.25);
+  border: solid 2px #eb5d1e;
+  border-radius: var(--accent-br);
+  z-index: 1;
+}
+
+.buttons {
+  padding: 10px var(--side-padding) 20px;
+  border-bottom-left-radius: var(--border-radius);
+  border-bottom-right-radius: var(--border-radius);
+}
+.calendar-button {
+  cursor: pointer;
+}
+
+/* for removing events from any date */
+.remove-class {
+  background-color: #f5f6f8;
+  color: #3f3d56;
+}
+.remove-class:hover {
+  box-shadow: 0 20px 30px -13px rgba(63, 61, 86, 0.45);
+  transform: translateY(-3px);
+}
+
+/* for adding events to any date */
+.add-class {
+  background-color: #3f3d56;
+  color: #fff;
+}
+
+.add-class:hover {
+  box-shadow: 0 20px 30px -13px rgba(63, 61, 86, 0.45);
+  transform: translateY(-3px);
+}
+
+body {
+  display: grid;
+  place-items: center;
+  background-color: #eaedf2;
+  height: 100vh;
+  font-family: 'Nunito', sans-serif;
+  font-size: 14px;
+  margin: 3vmin;
+}
+select,
+button {
+  font-family: inherit;
+  font-weight: 700;
+  font-size: 1.02rem;
+  border-radius: 20px;
+  outline: none;
+  border: 0;
+  padding: 15px 20px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+select {
+  background-image: url('/static/chevron-down.svg');
+  background-size: 24px;
+  background-repeat: no-repeat;
+  background-position: calc(100% - var(--side-padding)) center;
+}

--- a/static/chevron-down.svg
+++ b/static/chevron-down.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#3f3d5673" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-chevron-down"><polyline points="6 9 12 15 18 9"></polyline></svg>

--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+
+    {% load static %}
+    <title>{% block title %} Jagrati | Event Calendar {% endblock %} </title>
+    
+    {% block style %}
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <link rel="icon" type="text/css" href="{% static 'new_home/images/logo.png' %}">
+    
+    <link rel="stylesheet" href='{% static "new_home/style.css" %}'>
+    <link rel="stylesheet" href='{% static "calendar.css" %}'>    
+    {% endblock %}
+
+</head>
+<body>
+
+    {% block content %}
+    <!--Logo-->
+<center style="background-color: rgb(252,252,252)"><img src="{% static 'new_home/images/logo.png' %}"
+  style="height: 60px;"></center>
+
+<!--Navbar Starts-->
+<nav id="sticky">
+<div>
+  <!--Left Navbar-->
+  <div class="navbar" id="nav">
+      <a href="javascript:void(0);" class="icon" onclick="nav_button()" id="tus">
+          <div class="bar" onclick="rotate_menu(this)">
+              <div class="bar1"></div>
+              <div class="bar2"></div>
+              <div class="bar3"></div>
+          </div>
+      </a>
+
+      <a href="/" class="child-1">Home</a>
+      <a href="#about-us" class="child-2">About</a>
+      <a href="" class="child-3">Initiatives</a>
+      <a href="/" class="child-4">Team</a>
+      <a href="#contact" class="child-5">Contact</a>
+      <hr />
+  </div>
+
+  <!--Right Navbar-->
+  <div class="navbar1">
+      <ul>
+          <a href="{% url 'accounts:login_signup' %}">Login</a>
+          <p href="#about" class="btn-get-started scrollto">Donate</p>
+      </ul>
+  </div>
+</div>
+</nav>
+<!--Navbar Ends-->
+
+<!--Header Start-->
+<section id="header" class=" align-items-center">
+  <div class="container">
+    <div class="row">
+      
+      <div class="col-lg-6 pt-5 pt-lg-0 order-2 order-lg-1 mt-5 " data-aos="zoom-in" data-aos-offset="400"
+          data-aos-easing="ease-in-sine">
+          <h1>Welcome to <a style="color:#f17e01;" class="magica">Jagrati</a></h1>
+          <h2>We are a team of dedicated students, on a path to make this world a better place!</h2>
+          <a href="#about" class="btn-get-started scrollto">Donate</a>
+      </div>
+
+      <div class="calendar-area">
+        <div class="col-lg-6 order-1 order-lg-2 header-img" data-aos="zoom-in" data-aos-offset="400"
+          data-aos-easing="ease-in-sine">
+          <img src='{% static "new_home/images/edu.svg" %}' class="img-fluid animated" alt="">
+        </div>
+
+        <!--Calendar Starts-->
+        <div class="calendar">
+          <!--Dropdown Menus Start-->
+          <div class="options">
+            <select name="month" id="month">
+              <option>January</option>
+              <option>February</option>
+              <option selected>March</option>
+              <option>April</option>
+              <option>May</option>
+              <option>June</option>
+              <option>July</option>
+              <option>August</option>
+              <option>September</option>
+              <option>October</option>
+              <option>November</option>
+              <option>December</option>
+            </select>
+        
+            <select name="year" id="year">
+              <option>2018</option>
+              <option>2019</option>
+              <option>2020</option>
+              <option selected>2021</option>
+            </select>
+          </div>
+          <!--Dropdown Menus End-->
+
+          <!--Main Calendar Body Starts-->
+          <div class="calendar-body">
+            <div class="days">
+              <div>Sun</div>
+              <div>Mon</div>
+              <div>Tue</div>
+              <div>Wed</div>
+              <div>Thu</div>
+              <div>Fri</div>
+              <div>Sat</div>
+            </div>
+        
+            <div class="dates">
+              <div class="date date-blocked"><span>28</span></div> <!--Class date-blocked makes days from other visible months inaccessible-->
+              <div class="date"><span>1</span></div>
+              <div class="date"><span>2</span></div>
+              <div class="date"><span>3</span></div>
+              <div class="date"><span>4</span></div>
+              <div class="date"><span>5</span></div>
+              <div class="date" id="weekend"><span>6</span></div>
+              <div class="date"  id="weekend"><span>7</span></div>
+              <div class="date" id="holiday"><span>8</span></div>
+              <div class="date"><span>9</span></div>
+              <div class="date" id="holiday"><span>10</span></div>
+              <div class="date"><span>11</span></div>
+              <div class="date"><span>12</span></div>
+              <div class="date" id="weekend"><span>13</span></div>
+              <div class="date"  id="weekend"><span>14</span></div>
+              <div class="date"><span>15</span></div>
+              <div class="date"><span>16</span></div>
+              <div class="date"><span>17</span></div>
+              <div class="date"><span>18</span></div>
+              <div class="date"><span>19</span></div>
+              <div class="date" id="weekend"><span>20</span></div>
+              <div class="date" id="weekend"><span>21</span></div>
+              <div class="date current-date"><span>22</span></div>
+              <div class="date"><span>23</span></div>
+              <div class="date"><span>24</span></div>
+              <div class="date"><span>25</span></div>
+              <div class="date"><span>26</span></div>
+              <div class="date" id="weekend"><span>27</span></div>
+              <div class="date"  id="weekend"><span>28</span></div>
+              <div class="date" id="holiday"><span>29</span></div>
+              <div class="date"><span>30</span></div>
+              <div class="date"><span>31</span></div>
+              <div class="date date-blocked"><span>1</span></div>
+              <div class="date date-blocked"><span>2</span></div>
+              <div class="date date-blocked"><span>3</span></div>
+            </div>
+          </div>
+          <!--Main Calendar Body Ends-->
+        
+          <div class="buttons">
+            <!--To be used for removing events from any date-->
+            <button class="calendar-button remove-class">Remove</button>
+            <!--To be used for adding events to any date-->
+            <button class="calendar-button add-class">Add New</button>
+          </div>
+        </div>
+
+<!--Calendar Ends-->
+      </div>
+      
+    </div>
+  </div>
+</section>
+<!--Header Ends-->
+
+</br></br></br></br>
+      <!--Javascript to assign background colour according to event schedule-->
+      <script>
+          var i, containsNo, containsYes, weekend, holiday;
+          //will assign red background to days with no scheduled events
+          containsNo = document.querySelectorAll("#eventNo");
+          for (i = 0; i < containsNo.length; i++) {
+            containsNo[i].classList.add("redClass");
+          }
+          //will assign green background to days with scheduled events
+          containsYes = document.querySelectorAll("#eventYes");
+          for (i = 0; i < containsYes.length; i++) {
+            containsYes[i].classList.add("greenClass");
+          }
+          //assigns red background to weekends
+          weekend = document.querySelectorAll("#weekend");
+          for (i = 0; i < weekend.length; i++) {
+            weekend[i].classList.add("redClass");
+          }
+          //assigns red background to registered holidays
+          holiday = document.querySelectorAll("#holiday");
+          for (i = 0; i < holiday.length; i++) {
+            holiday[i].classList.add("redClass");
+          }
+        </script>
+    {% endblock %}
+
+</body>
+</html>


### PR DESCRIPTION
# Related Issue
Fixes: Calendar page, accessible at "/calendar/"

# Additional Info
Features:
1. Drop-down menus for month and year
2. Blocked out (overlapping) dates from other months
3. Red background for weekends and holidays, by default
4. Green background for weekdays, by default
5. Highlighted background for the current date
6. Add and Remove buttons for scheduling events. Dates with the appropriate ID will automatically get assigned a red/green background. Details about the IDs are present in the HTML file

# Screenshots

![Calendar_Month](https://user-images.githubusercontent.com/69975807/112040347-23019580-8b6b-11eb-94da-af76576299df.png)
![Calendar_Year](https://user-images.githubusercontent.com/69975807/112040357-2563ef80-8b6b-11eb-97ec-1d67812c61ee.png)

# Video


https://user-images.githubusercontent.com/69975807/112040384-2dbc2a80-8b6b-11eb-95b0-350a93dacab2.mp4

