### PR TITLE
Add tests for add_student view and moved tests in students app to tests folder

### DIFF
--- a/apps/students/tests.py
+++ b/apps/students/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/apps/students/tests/test_views.py
+++ b/apps/students/tests/test_views.py
@@ -1,0 +1,43 @@
+from django.test import SimpleTestCase,TestCase,Client
+from django.urls import reverse,resolve
+from accounts.models import User
+class TestViews(TestCase):
+    @classmethod
+    def setUp(self):
+        User.objects.create_superuser(
+            'user101@example.com',
+            'pswdt2gbjbuh',
+        )
+        self.client=Client()
+        self.client.login(username="user101@example.com", password="pswdt2gbjbuh")
+        self.un_auth_user=User.objects.create_user("user100@gmail.com","pswdt2gb")
+         
+    def tearDown(self):
+        self.client.logout()
+        
+    
+    def test_new_student(self):
+        payload_data ={
+               'first_name': "first_name",
+               'last_name':"last_name",
+               'gender':'M',
+               'school_class':4,
+               'village':'G',
+               'guardian_name': "guardian_name",
+            }
+            
+        response_post=self.client.post(reverse('students:add_student'),kwargs=payload_data,follow=True) 
+        response_get=self.client.get(reverse('students:add_student'),follow=True)
+        
+        redirected_response_get=self.client.get(reverse('students:add_student'))
+        redirected_response_post=self.client.post(reverse('students:add_student'),kwargs=payload_data)
+        
+        # Checking for unauthenticated users, to get redirected to correct url
+        # Getting correct status code for redirection
+        self.assertEquals(redirected_response_get.status_code,302)
+        self.assertEquals(redirected_response_post.status_code,302)
+        self.assertEquals(redirected_response_get.url,"/accounts/login/?next=/students/add/")
+        
+        # This is authenticated user so resp code 200
+        self.assertEquals(response_post.status_code,200)
+        self.assertEquals(response_get.status_code,200)   


### PR DESCRIPTION
# Related Issue
Fixes: [79](https://github.com/garg3133/JagratiWebApp/issues/79)

# Prosposed Changes
- Add test for GET and POST methods of authenticated and unauthenticated users.
- Check redirecting URLs and response status code for unauthenticated users

# Additional Info
- Due to adding the tests folder in ```apps/students``` folder, we need to delete existing tests.py to run the test scripts 
![tests_feature](https://user-images.githubusercontent.com/56113657/118310905-d0aa7880-b50c-11eb-9874-5ca8d35395fa.png)


# Screenshots
- My tests got passed with no errors

Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **