### PR TITLE
Added subject taught field in CW/HW section

### DIFF
--- a/home/views.py
+++ b/home/views.py
@@ -83,7 +83,7 @@ def dashboard(request):
         schedule_objects = Schedule.objects.all()
         query_taught = {}
         for items in schedule_objects:
-            query_taught[items.subject]=items.get_subject_display()
+            query_taught[items.subject] = items.get_subject_display()
 
         context = {
             'selected_date': query_date,
@@ -182,7 +182,6 @@ def update_cwhw(request):
         hw = request.POST['hw']
         comment = request.POST['comment']
 
-
         cw_hw = ClassworkHomework.objects.filter(
             cal_date=cal_date, section=section)
         if cw_hw.exists():
@@ -191,7 +190,7 @@ def update_cwhw(request):
             if cw or hw or comment:
                 cw_hw = ClassworkHomework(
                     cal_date=cal_date, section=section, cw='', hw='', comment='', subject_taught=subject_taught, to_be_taught=to_be_taught)
-            else :
+            else:
                 redirect_url = reverse('home:dashboard') + f'?d={date}&s={section_id}'
                 return HttpResponseRedirect(redirect_url)
 

--- a/home/views.py
+++ b/home/views.py
@@ -80,10 +80,7 @@ def dashboard(request):
         else:
             return redirect('home:dashboard')
 
-        schedule_objects = Schedule.objects.all()
-        query_taught = {}
-        for items in schedule_objects:
-            query_taught[items.subject] = items.get_subject_display()
+        query_taught = Schedule.SUBJECT
 
         context = {
             'selected_date': query_date,
@@ -174,8 +171,7 @@ def update_cwhw(request):
         section_id = request.POST['section']
         section = Section.objects.get(section_id=section_id)
 
-        to_be_taught = request.POST['extra-info-2']
-        subject_taught = request.POST['t']
+        subject_taught = request.POST['subject_taught']
 
         # Update CW-HW
         cw = request.POST['cw']
@@ -191,8 +187,7 @@ def update_cwhw(request):
             if cw or hw or comment:
                 cw_hw = ClassworkHomework(
                     cal_date=cal_date, section=section, cw='', hw='',
-                    comment='', subject_taught=subject_taught,
-                    to_be_taught=to_be_taught)
+                    comment='', subject_taught=subject_taught)
             else:
                 return HttpResponseRedirect(redirect_url)
 

--- a/home/views.py
+++ b/home/views.py
@@ -80,9 +80,15 @@ def dashboard(request):
         else:
             return redirect('home:dashboard')
 
+        schedule_objects = Schedule.objects.all()
+        query_taught = {}
+        for items in schedule_objects:
+            query_taught[items.subject]=items.get_subject_display()
+
         context = {
             'selected_date': query_date,
             'selected_section': query_section,
+            'selected_subject': query_taught,
         }
         # If calendar instance for that day is not created
         if not calendar.exists():
@@ -168,18 +174,26 @@ def update_cwhw(request):
         section_id = request.POST['section']
         section = Section.objects.get(section_id=section_id)
 
+        to_be_taught = request.POST['extra-info-2']
+        subject_taught = request.POST['t']
+
         # Update CW-HW
         cw = request.POST['cw']
         hw = request.POST['hw']
         comment = request.POST['comment']
+
 
         cw_hw = ClassworkHomework.objects.filter(
             cal_date=cal_date, section=section)
         if cw_hw.exists():
             cw_hw = cw_hw[0]
         else:
-            cw_hw = ClassworkHomework(
-                cal_date=cal_date, section=section, cw='', hw='', comment='')
+            if cw or hw or comment:
+                cw_hw = ClassworkHomework(
+                    cal_date=cal_date, section=section, cw='', hw='', comment='', subject_taught=subject_taught, to_be_taught=to_be_taught)
+            else :
+                redirect_url = reverse('home:dashboard') + f'?d={date}&s={section_id}'
+                return HttpResponseRedirect(redirect_url)
 
         if cw:
             cw_hw.cw += f'{cw}\n - {profile.get_full_name}, {volun.roll_no}\n\n'

--- a/home/views.py
+++ b/home/views.py
@@ -182,6 +182,7 @@ def update_cwhw(request):
         hw = request.POST['hw']
         comment = request.POST['comment']
 
+        redirect_url = reverse('home:dashboard') + f'?d={date}&s={section_id}'
         cw_hw = ClassworkHomework.objects.filter(
             cal_date=cal_date, section=section)
         if cw_hw.exists():
@@ -189,9 +190,10 @@ def update_cwhw(request):
         else:
             if cw or hw or comment:
                 cw_hw = ClassworkHomework(
-                    cal_date=cal_date, section=section, cw='', hw='', comment='', subject_taught=subject_taught, to_be_taught=to_be_taught)
+                    cal_date=cal_date, section=section, cw='', hw='',
+                    comment='', subject_taught=subject_taught,
+                    to_be_taught=to_be_taught)
             else:
-                redirect_url = reverse('home:dashboard') + f'?d={date}&s={section_id}'
                 return HttpResponseRedirect(redirect_url)
 
         if cw:
@@ -204,7 +206,6 @@ def update_cwhw(request):
         cw_hw.save()
 
         messages.success(request, 'CW_HW update successful!')
-        redirect_url = reverse('home:dashboard') + f'?d={date}&s={section_id}'
         return HttpResponseRedirect(redirect_url)
 
     return redirect('home:dashboard')

--- a/templates/home/dashboard.html
+++ b/templates/home/dashboard.html
@@ -41,10 +41,17 @@
         <p class="text-center">{{calendar_remark}}</p>
         {% else %}
         <!-- Subject Scheduled -->
-        <div class="row justify-content-center mt-4">
-            {% if subject_scheduled %}
-            <p>Subject scheduled: <b>{{ subject_scheduled }}</b></p>
-            {% endif %}
+        <div class="row justify-content-center mt-4 mx-5">
+            <div class="col-md-9 col-lg-3 mr-lg-5 mb-3">
+                {% if subject_scheduled %}
+                <p>Subject scheduled: <b>{{ subject_scheduled }}</b></p>
+                {% endif %}
+            </div>
+            <div class="col-md-9 col-lg-3 mr-lg-5 mb-3">
+                {% if subject_scheduled %}
+                <p>Subject Taught: <b id="sub-taught">{{ subject_scheduled }}</b></p>
+                {% endif %}
+            </div>
         </div>
 
         <!-- ClassWork HomeWork -->
@@ -84,13 +91,28 @@
                 <i style="margin-left:10px !important;" class="fas fa-chevron-down"></i>
             </button>
         </div>
-
         <div class="row justify-content-center mt-3 px-3" style="background-color: #f7f7f7;">
             <div class="dash-cwhw d-none col-12">
                 <form action="{% url 'home:update_cwhw' %}" method="POST" class="mt-4">
                     {% csrf_token %}
                     <input type="hidden" name="date" value="{{ selected_date|date:'Y-m-d' }}">
                     <input type="hidden" name="section" value="{{ selected_section }}">
+                    <div class="row justify-content-center mb-2">
+                        <div class="col-md-9 col-lg-3 mr-lg-5 mb-3">
+                            <label for="subject-taught">Subject taught</label>
+                            <select name="t" class="custom-select d-block w-100" id="subject-taught" onchange="fetchSubject()" required >
+                                {% for key, value in selected_subject.items %}
+                                    {% if value == subject_scheduled %}
+                                        <option value={{key}} selected>{{ value }}</option>
+                                    {% else %}
+                                        <option value={{key}}>{{ value }}</option>
+                                    {% endif %}
+                                {% endfor %}
+                            </select>
+                        </div>
+                    </div>
+                    <!-- Hidden Input For Scheduled Subject -->
+                    <input type="hidden" name="extra-info-2" value="{{ subject_scheduled }}">
                     <div class="row justify-content-center mb-2">
                         <div class="col-md-9 col-lg-5 px-0 mr-lg-5 mb-3">
                             <textarea name="cw" id="update_cw" class="form-control" data-tooltip="update_cwhw" rows="6"
@@ -342,6 +364,15 @@
         $('#class-date').datepicker("setDate", "{{ selected_date|date:'Y-m-d' }}");
     else
         $('#class-date').datepicker("setDate", "{% now 'Y-m-d' %}");
+</script>
+
+<!-- Script for Subject Taught -->
+<script>
+    function fetchSubject() {
+      var subject_taught_key = document.getElementById("subject-taught").value;
+      var subject_taught_dict = {{ selected_subject|safe }}
+      document.getElementById("sub-taught").innerHTML = subject_taught_dict[subject_taught_key];
+    }
 </script>
 
 <!-- Search Filter for Student Present on Dashboard  -->

--- a/templates/home/dashboard.html
+++ b/templates/home/dashboard.html
@@ -48,8 +48,10 @@
                 {% endif %}
             </div>
             <div class="col-md-9 col-lg-3 mr-lg-5 mb-3">
-                {% if subject_scheduled %}
-                <p>Subject Taught: <b id="sub-taught">{{ subject_scheduled }}</b></p>
+                {% if cw_hw.get_subject_taught_display %}
+                <p>Subject Taught: <b>{{ cw_hw.get_subject_taught_display }}</b></p>
+                {% else %}
+                <p>Subject Taught: <b>Not Updated</b></p>
                 {% endif %}
             </div>
         </div>
@@ -100,8 +102,8 @@
                     <div class="row justify-content-center mb-2">
                         <div class="col-md-9 col-lg-3 mr-lg-5 mb-3">
                             <label for="subject-taught">Subject taught</label>
-                            <select name="t" class="custom-select d-block w-100" id="subject-taught" onchange="fetchSubject()" required >
-                                {% for key, value in selected_subject.items %}
+                            <select name="subject_taught" class="custom-select d-block w-100" id="subject-taught" required >
+                                {% for key, value in selected_subject %}
                                     {% if value == subject_scheduled %}
                                         <option value={{key}} selected>{{ value }}</option>
                                     {% else %}
@@ -364,15 +366,6 @@
         $('#class-date').datepicker("setDate", "{{ selected_date|date:'Y-m-d' }}");
     else
         $('#class-date').datepicker("setDate", "{% now 'Y-m-d' %}");
-</script>
-
-<!-- Script for Subject Taught -->
-<script>
-    function fetchSubject() {
-      var subject_taught_key = document.getElementById("subject-taught").value;
-      var subject_taught_dict = {{ selected_subject|safe }}
-      document.getElementById("sub-taught").innerHTML = subject_taught_dict[subject_taught_key];
-    }
 </script>
 
 <!-- Search Filter for Student Present on Dashboard  -->


### PR DESCRIPTION
# Related Issue
Fixes: #176

# Prosposed Changes
- Added a select input field in 'Update CW/HW' section on the dashboard for marking which subject was actually taught in the class
- The selected value in the select input defaults to the subject scheduled on that day
- The selected value will be saved to the database only if the CW, HW and comment fields are not all empty
- Displayed the Subject Taught alongside the Subject Scheduled field

# Screenshots

Original             |  Updated
:-------------------------:|:-------------------------:
![original](https://user-images.githubusercontent.com/56936116/119874001-cd6ab000-bf42-11eb-970a-466890731497.png)  |  ![updated_1](https://user-images.githubusercontent.com/56936116/119874061-d9ef0880-bf42-11eb-9595-127f8197bf89.png)
